### PR TITLE
Handle SIGPIPE

### DIFF
--- a/webvulnscan/__init__.py
+++ b/webvulnscan/__init__.py
@@ -1,4 +1,5 @@
 from optparse import OptionParser, OptionGroup
+import signal
 
 from .utils import read_config, write_config
 
@@ -199,6 +200,9 @@ def parse_options():
 
 
 def main():
+    # Handle SIGPIPE (sent when someone is processing our output and is done)
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
     options, arguments = parse_options()
 
     if options.write_config:


### PR DESCRIPTION
When somebody parses the output of webvulnscan and has read enough (for example because only one line is necessary, see #31), Python by default crashes with an unsightly

```
<long traceback>
IOError: [Errno 32] Broken pipe
```

Instead, webvulnscan should simply exit; that's the default action for the signal anyway.
To test, try

```
python -m webvulnscan http://localhost:8666/ -v | head -n 1
```
